### PR TITLE
 #44: Update udev configuration to use 'ATTR' instead of 'SYSFS'

### DIFF
--- a/41-odvr.rules
+++ b/41-odvr.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", SYSFS{idVendor}=="07b4", SYSFS{idProduct}=="020d", ACTION=="add", GROUP="audio", MODE="0664"
+SUBSYSTEM=="usb", ATTR{idVendor}=="07b4", ATTR{idProduct}=="020d", ACTION=="add", GROUP="audio", MODE="0664"


### PR DESCRIPTION
Provide the configuration update for the related issue (#44)